### PR TITLE
Update to support Laravel JSON:API v5.x 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "laravel-json-api/core": "^4.0",
+        "laravel-json-api/core": "^5.0",
         "laravel-json-api/eloquent": "^4.0",
         "vinkla/hashids": "^12.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "laravel-json-api/core": "^5.0",
+        "laravel-json-api/core": "^4.0|^5.0",
         "laravel-json-api/eloquent": "^4.0",
         "vinkla/hashids": "^12.0"
     },


### PR DESCRIPTION
This library doesn't at present support v5.x of https://github.com/laravel-json-api/laravel

This PR will resolve this.

```
david.weston@Westies-WorkBook-Pro hashids % ./vendor/bin/phpunit 
PHPUnit 10.5.41 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.9
Configuration: /Users/david.weston/www-data/hashids/phpunit.xml

...............                                                   15 / 15 (100%)

Time: 00:00.079, Memory: 22.00 MB

OK (15 tests, 25 assertions)
```